### PR TITLE
Support for organizations in aging "studies" (SCM)

### DIFF
--- a/grimoirelib_alch/tests/test_family_activity_persons.py
+++ b/grimoirelib_alch/tests/test_family_activity_persons.py
@@ -1,0 +1,100 @@
+# -*- coding: utf-8 -*-
+
+## Copyright (C) 2015 Bitergia
+##
+## This program is free software; you can redistribute it and/or modify
+## it under the terms of the GNU General Public License as published by
+## the Free Software Foundation; either version 3 of the License, or
+## (at your option) any later version.
+##
+## This program is distributed in the hope that it will be useful,
+## but WITHOUT ANY WARRANTY; without even the implied warranty of
+## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+## GNU General Public License for more details.
+##
+## You should have received a copy of the GNU General Public License
+## along with this program; if not, write to the Free Software
+## Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+##
+## Unit tests for family.activity_persons
+## 
+## Authors:
+##   Jesus M. Gonzalez-Barahona <jgb@bitergia.com>
+##
+
+from grimoirelib_alch.query.scm import DB
+from grimoirelib_alch.family.scm import (
+    SCM, 
+    PeriodCondition as SCMPeriodCondition,
+    NomergesCondition as SCMNomergesCondition,
+    OrgsCondition as SCMOrgsCondition
+    )
+from grimoirelib_alch.family.activity_persons import SCMActivityPersons 
+from grimoirelib_alch.type.activity import Period, ActivityList
+from datetime import datetime
+from sqlalchemy.util import KeyedTuple
+import unittest
+
+url = 'mysql://jgb:XXX@localhost/'
+schema = 'oscon_openstack_scm'
+schema_id = 'oscon_openstack_scm'
+start = datetime(2013,11,13)
+end = datetime(2014,2,1)
+datefmt = "%Y-%m-%d %H:%M:%S"
+rowlabels = ["person_id", "name", "firstdate", "lastdate"]
+
+class TestActivityPersons (unittest.TestCase):
+
+    def setUp (self):
+
+        self.database = DB (url = url,
+                            schema = schema,
+                            schema_id = schema_id)
+        self.session = self.database.build_session()
+        self.start = start
+        self.end = end
+
+    def test_orgs_condition (self):
+        """Test SCMActivityPersons object with an organizations condition"""
+
+        correct = ActivityList(
+            (KeyedTuple([774, u'John Dickinson',
+                         datetime.strptime("2013-11-15 15:10:39", datefmt),
+                         datetime.strptime("2014-01-24 14:53:17", datefmt)
+                         ],
+                        labels = rowlabels
+                        ),
+             KeyedTuple([1094, u'Samuel Merritt',
+                         datetime.strptime("2013-11-13 12:52:21", datefmt),
+                         datetime.strptime("2014-01-31 13:17:00", datefmt)
+                         ],
+                        labels = rowlabels                        
+                        ),
+             KeyedTuple([2071, u'Darrell Bishop',
+                         datetime.strptime("2013-11-27 00:37:02", datefmt),
+                         datetime.strptime("2013-11-27 12:07:42", datefmt)
+                         ],
+                        labels = rowlabels                        
+                        ),
+             KeyedTuple([2110, u'Jon Snitow',
+                         datetime.strptime("2014-01-29 13:02:54", datefmt),
+                         datetime.strptime("2014-01-29 13:02:54", datefmt)
+                         ],
+                        labels = rowlabels                        
+                        )
+             )
+            )
+
+        period = SCMPeriodCondition (start = self.start, end = self.end)
+        nomerges = SCMNomergesCondition()
+        orgs = SCMOrgsCondition (orgs = ("SwiftStack", "Inktank"),
+                                 actors = "authors")
+        data = SCMActivityPersons (
+            datasource = self.session,
+            name = "list_authors", conditions = (period,nomerges,orgs))
+        activity = data.activity()
+        print activity
+        self.assertEqual (data.activity(), correct)
+
+if __name__ == "__main__":
+    unittest.main()

--- a/grimoirelib_alch/tests/test_family_scm_orgs.py
+++ b/grimoirelib_alch/tests/test_family_scm_orgs.py
@@ -1,0 +1,59 @@
+# -*- coding: utf-8 -*-
+
+## Copyright (C) 2015 Bitergia
+##
+## This program is free software; you can redistribute it and/or modify
+## it under the terms of the GNU General Public License as published by
+## the Free Software Foundation; either version 3 of the License, or
+## (at your option) any later version.
+##
+## This program is distributed in the hope that it will be useful,
+## but WITHOUT ANY WARRANTY; without even the implied warranty of
+## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+## GNU General Public License for more details.
+##
+## You should have received a copy of the GNU General Public License
+## along with this program; if not, write to the Free Software
+## Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+##
+## Unit tests for family.scm.py related to organizations
+## 
+## Authors:
+##   Jesus M. Gonzalez-Barahona <jgb@bitergia.com>
+##
+
+from grimoirelib_alch.query.scm import DB
+from grimoirelib_alch.family.scm import (
+    SCM, OrgsCondition
+    )
+from datetime import datetime
+import unittest
+
+url = 'mysql://jgb:XXX@localhost/'
+schema = 'oscon_openstack_scm'
+schema_id = 'oscon_openstack_scm'
+start = datetime(2013,11,13)
+end = datetime(2014,2,1)
+
+class TestSCMOrgs (unittest.TestCase):
+
+    def setUp (self):
+
+        self.database = DB (url = url,
+                            schema = schema,
+                            schema_id = schema_id)
+        self.session = self.database.build_session()
+        self.start = start
+        self.end = end
+
+    def test_orgs_condition (self):
+        """Test SCM object with an organizations condition"""
+
+        orgs = OrgsCondition (orgs = ("Red Hat", "Midokura", "HP"),
+                              actors = "authors")
+        data = SCM (datasource = self.database, name = "ncommits",
+                    conditions = (orgs,))
+        self.assertEqual (data.total(), 20115)
+
+if __name__ == "__main__":
+    unittest.main()

--- a/grimoirelib_alch/tests/test_query_scm_orgs.py
+++ b/grimoirelib_alch/tests/test_query_scm_orgs.py
@@ -63,9 +63,7 @@ class TestSCMQueryOrgs (unittest.TestCase):
 
         res = self.session.query().select_orgs() \
             .filter_orgs(org[1] for org in correct)
-        for row in res.all():
-            print row.org_id, row.org_name
-        self.assertEqual (res.limit(5).all(), correct)
+        self.assertEqual (res.all(), correct)
 
 
 if __name__ == "__main__":

--- a/grimoirelib_alch/tests/test_query_scm_orgs.py
+++ b/grimoirelib_alch/tests/test_query_scm_orgs.py
@@ -70,11 +70,14 @@ class TestSCMQueryOrgs (unittest.TestCase):
 
         """
 
-        correct = 11518
+        correct = (11518,11626)
 
         res = self.session.query().select_nscmlog(["commits",]) \
             .filter_org_ids(list = (1,2,), kind = "authors")
-        self.assertEqual (res.scalar(), correct)
+        self.assertEqual (res.scalar(), correct[0])
+        res = self.session.query().select_nscmlog(["commits",]) \
+            .filter_org_ids(list = (1,2,), kind = "committers")
+        self.assertEqual (res.scalar(), correct[1])
 
 
 if __name__ == "__main__":

--- a/grimoirelib_alch/tests/test_query_scm_orgs.py
+++ b/grimoirelib_alch/tests/test_query_scm_orgs.py
@@ -1,0 +1,72 @@
+# -*- coding: utf-8 -*-
+
+## Copyright (C) 2015 Bitergia
+##
+## This program is free software; you can redistribute it and/or modify
+## it under the terms of the GNU General Public License as published by
+## the Free Software Foundation; either version 3 of the License, or
+## (at your option) any later version.
+##
+## This program is distributed in the hope that it will be useful,
+## but WITHOUT ANY WARRANTY; without even the implied warranty of
+## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+## GNU General Public License for more details.
+##
+## You should have received a copy of the GNU General Public License
+## along with this program; if not, write to the Free Software
+## Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+##
+## Unit tests for scm_query.py related to organizations
+## 
+## Authors:
+##   Jesus M. Gonzalez-Barahona <jgb@bitergia.com>
+##
+
+from grimoirelib_alch.query.scm import DB, Query
+import unittest
+
+url = 'mysql://jgb:XXX@localhost/'
+schema = 'oscon_openstack_scm'
+schema_id = 'oscon_openstack_scm'
+
+class TestSCMQueryOrgs (unittest.TestCase):
+
+    def setUp (self):
+        database = DB (url = url,
+                       schema = schema,
+                       schema_id = schema_id)
+        self.session = database.build_session(Query, echo = False)
+
+    def test_select_orgs (self):
+        """Test select_orgs
+
+        """
+
+        correct = [(1, "Red Hat"),
+                   (2, "Midokura"),
+                   (3, "Inktank"),
+                   (4, "IBM"),
+                   (5, "HP")]
+
+        res = self.session.query().select_orgs()
+        self.assertEqual (res.limit(5).all(), correct)
+
+    def test_filter_orgs (self):
+        """Test select_orgs
+
+        """
+
+        correct = [(1, "Red Hat"),
+                   (2, "Midokura"),
+                   (4, "IBM"),
+                   (5, "HP")]
+
+        res = self.session.query().select_orgs() \
+            .filter_orgs(org[1] for org in correct)
+        for row in res.all():
+            print row.org_id, row.org_name
+        self.assertEqual (res.limit(5).all(), correct)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/grimoirelib_alch/tests/test_query_scm_orgs.py
+++ b/grimoirelib_alch/tests/test_query_scm_orgs.py
@@ -65,6 +65,17 @@ class TestSCMQueryOrgs (unittest.TestCase):
             .filter_orgs(org[1] for org in correct)
         self.assertEqual (res.all(), correct)
 
+    def test_filter_org_ids (self):
+        """Test filter_org_ids
+
+        """
+
+        correct = 11518
+
+        res = self.session.query().select_nscmlog(["commits",]) \
+            .filter_org_ids(list = (1,2,), kind = "authors")
+        self.assertEqual (res.scalar(), correct)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/vizgrimoire/analysis/ages.py
+++ b/vizgrimoire/analysis/ages.py
@@ -26,7 +26,8 @@
 from grimoirelib_alch.query.scm import DB as SCMDatabase
 from grimoirelib_alch.family.scm import (
     NomergesCondition as SCMNomergesCondition,
-    PeriodCondition as SCMPeriodCondition
+    PeriodCondition as SCMPeriodCondition,
+    OrgsCondition as SCMOrgsCondition
     )
 from grimoirelib_alch.query.its import DB as ITSDatabase
 from grimoirelib_alch.family.its import PeriodCondition as ITSPeriodCondition
@@ -68,6 +69,40 @@ def produce_json (filename, data, compact = True):
     data_json = encode(data, unpicklable=False)
     with codecs.open(filename, "w", "utf-8") as file:
         file.write(data_json)
+
+def parse_analysis (type_analysis):
+    """Parse a "type_analysis", returning a dictionary.
+
+    Gets as parameter a "type_analysis", which is one of the
+    filters that a metrics object can include, and produces
+    a dictionary in it. "type_analysis" is a list with two
+    elements, of the form ["company,repo", "'SwiftStack','onerepo'"].
+    With it, produces a dictionary such as:
+    {"company": "SwiftStack", "repo": "onerepo"}
+    
+    Parametrers
+    -----------
+    
+    type_analysis: list of str
+        type_analysis to parse
+    
+    Returns
+    -------
+
+    dict: dictionary
+    
+    """
+
+    analysis_dict = {}
+    analysis_list = type_analysis[0].split(",")
+    values_list = type_analysis[1].split(",")
+    for i, analysis in enumerate(analysis_list):
+        value = values_list[i]
+        if value.startswith("'") and value.endswith("'"):
+            value = value[1:-1]
+        analysis_dict[analysis] = value
+    return analysis_dict
+
 
 class Ages(Analyses):
     """Clase for calculating the Ages analysis.
@@ -115,6 +150,8 @@ class Ages(Analyses):
         # Get startdate, endate as datetime objects
         startdate = datetime.strptime(self.filters.startdate, "'%Y-%m-%d'")
         enddate = datetime.strptime(self.filters.enddate, "'%Y-%m-%d'")
+        # Get dictionary with analysis, if any
+        analysis_dict = parse_analysis (self.filters.type_analysis)
         if data_source == SCM:
             logging.info("Analyzing aging for SCM")
             # Activity data (start time, end time for contributions) for
@@ -123,13 +160,19 @@ class Ages(Analyses):
             # as activity)
             period = SCMPeriodCondition (start = startdate, end = enddate)
             nomerges = SCMNomergesCondition()
+            conditions = [period, nomerges]
+            if self.filters.COMPANY in analysis_dict:
+                orgs = SCMOrgsCondition (
+                    orgs = (analysis_dict[self.filters.COMPANY],),
+                    actors = "authors")
+                conditions.append(orgs)
             database = SCMDatabase (url = url,
                                     schema = schema,
                                     schema_id = schema_id)
             data = SCMActivityPersons (
                 datasource = database,
                 name = "list_uauthors",
-                conditions = (period, nomerges))
+                conditions = conditions)
         elif data_source == ITS:
             logging.info("Analyzing aging for ITS")
             # Activity data (start time, end time for contributions) for
@@ -227,8 +270,10 @@ if __name__ == '__main__':
     from vizgrimoire.metrics.query_builder import DSQuery
     from vizgrimoire.metrics.metrics_filter import MetricFilters
 
-    # Get 
     filters = MetricFilters("months", "'2013-06-01'", "'2014-01-01'", [])
+    # Warning: next "Red Hat" string will be changed to "'Red Hat'" by
+    # the internals of Automator etc.
+    filters.add_filter (filters.COMPANY, "SwiftStack")
     dbcon = DSQuery(user = "jgb", password = "XXX", 
                     database = "oscon_openstack_scm",
                     identities_db = "oscon_openstack_scm")


### PR DESCRIPTION
This should support the filters including analysis specifying that only data for a company should be produced, for the aging analysis. For now it only supports SCM. If it works well here, I can write the code for other data sources.

Maybe the function parse_analysis in visgrimoire/analysis/ages.py is general enough to include e.g. in metrics_filter.py as an utility function. It allows to deal with analysis as a dictionary, which I guess is more covnenient than the current data structure.

I did some relatively careful testing of the code under grimoirelib_alch, but only very limited of the code under vizgrimoire, so please check with any test that may be convenient.