### PR TITLE
Fixed problem with time periods in TZ analysis for MLS.

### DIFF
--- a/vizgrimoire/analysis/timezone.py
+++ b/vizgrimoire/analysis/timezone.py
@@ -119,7 +119,8 @@ class Timezone(Analyses):
                 conditions = (period, nomerges))
         elif data_source == MLS:
             logging.info("Analyzing timezone for MLS")
-            period = MLSPeriodCondition (start = startdate, end = enddate)
+            period = MLSPeriodCondition (start = startdate, end = enddate,
+                                         date = "first")
             database = MLSDatabase (url = url,
                                     schema = schema,
                                     schema_id = schema_id)


### PR DESCRIPTION
This should fix the problem with TZ not working properly in some databases when a date period was specified. In fact, the problem was that time periods were checked against messages.arrival_time, which is some cases is NULL for all messages. Instead, for the case of TZ analysis, the check for time periods goes now always against messages.first_time, which should exist (otherwise, no TZ analysis is possible).