### PR TITLE
Support for ages (demography) in MLS and ITS

### DIFF
--- a/grimoirelib_alch/family/common.py
+++ b/grimoirelib_alch/family/common.py
@@ -246,3 +246,81 @@ class DBCondition (Condition):
         """
 
         return query
+
+
+class Entities(type):
+    """Watcher for a metaclass, maintaining a dictionary with its subclasses
+
+    This watcher class maintains a dictionary with all the subclasses of
+    the metaclass that uses it.
+
+    Attributes
+    ----------
+
+    subclasses : dictionary
+        Subclasses of metaclass, keyed by name attribute of each subclass
+        (values are the subclasses themselves)
+
+    """
+
+    subclasses = {}
+
+    def __init__(cls, name, bases, clsdict):
+        """Add subclass cls to subclasses, keyed by its name attribute.
+
+        """
+
+        if clsdict['name'] is not None:
+            Entities.subclasses[clsdict['name']] = cls
+    
+
+class Entity ():
+    """Metaclass, root of all entities.
+
+    This is the root of the hierarchy of entities.
+    It uses a watcher for keeping a dictionary with all its subclasses.
+    Defines attributes and methods to be used in all the hierarchy.
+
+    Attributes
+    ----------
+
+    name: str
+        Entity name used for the entity represented by the class
+    desc: str
+        Description of the entity (one line)
+    longdesc: str
+        Description of the entity (long)
+
+    Methods
+    -------
+
+    query (q)
+        Returns the query to produce the entity
+
+    """
+
+    __metaclass__ = Entities
+
+    name = None
+    desc = None
+    longdesc = None
+
+    @staticmethod
+    def query (q):
+        """Return the query to produce this entity.
+
+        Parameters
+        ----------
+
+        q: query.scm.Query
+            Base query
+
+        Returns
+        -------
+
+        query.scm.Query
+            Query with the needed filters to produce the entity.
+
+        """
+
+        raise Exception ("query(): real entities should provide real code")

--- a/grimoirelib_alch/family/its.py
+++ b/grimoirelib_alch/family/its.py
@@ -23,8 +23,77 @@
 ##   Jesus M. Gonzalez-Barahona <jgb@bitergia.com>
 ##
 
-from common import DBFamily, DBCondition
+from common import DBFamily, DBCondition, Entities, Entity
 from grimoirelib_alch.query.its import DB, Query
+
+class Persons (Entity):
+    """Number of persons
+
+    """
+
+    name = "npersons"
+    desc = "Number of persons in ITS"
+    longdesc = "Number of persons in issue tracking system"
+
+    @staticmethod
+    def query (q):
+
+        return q.select_personsdata_uid("openers").distinct()
+
+
+class ITS (DBFamily):
+    """Constructor of entities in the ITS family.
+
+    This class can be used to instantiate entities from the ITS
+    fammily: direct entities obtained querying a Bicho database.
+
+    The entity to be instantiated is specified using its name, and
+    a set of zero or more conditions that provide context.
+
+    This class provides functions to return different kinds of aggregation
+    (timeseries, total, list) and selection (dates, etc.).
+
+    Valid entity names: "npersons".
+
+    """
+
+    def _produce_query (self, name):
+        """Produce the base query to obtain activity per person.
+
+        This function assumes that self.query was already initialized.
+        The produced query replaces self.query.
+        Conditions will be applied (as filters) later to the query
+        produced by this function.
+
+        Parameters
+        ----------
+        
+        name: {"npersons"}
+           Entity name.
+
+        """
+
+        if name in Entities.subclasses:
+            self.query = Entities.subclasses[name].query(self.query)
+        else:
+            raise Exception ("SCM: Invalid entity name for this family, " + \
+                                 name)
+
+    def timeseries (self):
+        """Return a timeseries for the entity"""
+
+        return self.query.count().group_by_period().timeseries()
+
+    def total (self):
+        """Return the total count for the entity"""
+
+        return self.query.count()
+
+    def list (self, limit = 10):
+        """Return a list for the specified entity"""
+
+        return self.query.limit(limit).all()
+
 
 class PeriodCondition (DBCondition):
     """Period Condition for qualifying a variable
@@ -54,6 +123,48 @@ class PeriodCondition (DBCondition):
         self.end = end
         self.date = date
 
+class OrgsCondition (DBCondition):
+    """Organization Condition for qualifying an entity.
+
+    Specifies the organizations of interest: only their activity will
+    be considered.
+    """
+
+    def __init__ (self, orgs, actors = "changers"):
+        """Instatiation of the object.
+
+        Parameters
+        ----------
+
+        orgs: list of str
+           List of organziations of interest 
+        actors: {"authors", "committers"}
+            Kind of actors to consider
+
+        """
+
+        self.org_names = orgs
+        self.actors = actors
+
+    def filter (self, query):
+        """Filter to apply for this condition
+
+        Parameters
+        ----------
+
+        query: Query
+           Query to which the filter will be applied
+
+        """
+
+        # Get the session for this query, use it for getting org ids,
+        # and build the filter
+        session = inspect(query).session
+        query_orgs = session.query().select_orgs() \
+            .filter_orgs (self.org_names)
+        self.org_ids = [org.org_id for org in query_orgs.all()]
+        return query.filter_org_ids(list = self.org_ids,
+                                    kind = self.actors)
 
 if __name__ == "__main__":
 

--- a/grimoirelib_alch/family/its.py
+++ b/grimoirelib_alch/family/its.py
@@ -25,6 +25,7 @@
 
 from common import DBFamily, DBCondition, Entities, Entity
 from grimoirelib_alch.query.its import DB, Query
+from sqlalchemy import inspect
 
 class Persons (Entity):
     """Number of persons
@@ -76,7 +77,7 @@ class ITS (DBFamily):
         if name in Entities.subclasses:
             self.query = Entities.subclasses[name].query(self.query)
         else:
-            raise Exception ("SCM: Invalid entity name for this family, " + \
+            raise Exception ("ITS: Invalid entity name for this family, " + \
                                  name)
 
     def timeseries (self):

--- a/grimoirelib_alch/family/mls.py
+++ b/grimoirelib_alch/family/mls.py
@@ -23,8 +23,78 @@
 ##   Jesus M. Gonzalez-Barahona <jgb@bitergia.com>
 ##
 
-from common import DBFamily, DBCondition
+from common import DBFamily, DBCondition, Entities, Entity
 from grimoirelib_alch.query.mls import DB, Query
+from sqlalchemy import inspect
+
+class Persons (Entity):
+    """Number of persons
+
+    """
+
+    name = "npersons"
+    desc = "Number of persons in MLS"
+    longdesc = "Number of persons in mailing lists"
+
+    @staticmethod
+    def query (q):
+
+        return q.select_personsdata_uid("senders").distinct()
+
+
+class MLS (DBFamily):
+    """Constructor of entities in the MLS family.
+
+    This class can be used to instantiate entities from the MLS
+    fammily: direct entities obtained querying a Bicho database.
+
+    The entity to be instantiated is specified using its name, and
+    a set of zero or more conditions that provide context.
+
+    This class provides functions to return different kinds of aggregation
+    (timeseries, total, list) and selection (dates, etc.).
+
+    Valid entity names: "npersons".
+
+    """
+
+    def _produce_query (self, name):
+        """Produce the base query to obtain activity per person.
+
+        This function assumes that self.query was already initialized.
+        The produced query replaces self.query.
+        Conditions will be applied (as filters) later to the query
+        produced by this function.
+
+        Parameters
+        ----------
+        
+        name: {"npersons"}
+           Entity name.
+
+        """
+
+        if name in Entities.subclasses:
+            self.query = Entities.subclasses[name].query(self.query)
+        else:
+            raise Exception ("MLS: Invalid entity name for this family, " + \
+                                 name)
+
+    def timeseries (self):
+        """Return a timeseries for the entity"""
+
+        return self.query.count().group_by_period().timeseries()
+
+    def total (self):
+        """Return the total count for the entity"""
+
+        return self.query.count()
+
+    def list (self, limit = 10):
+        """Return a list for the specified entity"""
+
+        return self.query.limit(limit).all()
+
 
 class PeriodCondition (DBCondition):
     """Period Condition for qualifying an entity.
@@ -54,8 +124,10 @@ class PeriodCondition (DBCondition):
             Start of the period.
         end: datetime.datetime
             End of the period.
-        date: { "first", "arrival" }
-            Select "first_date" or "arrival_date" from messages.
+        date: { "first" | "arrival" | "check" }
+            Select "first_date" or "arrival_date" from messages,
+            ir check which one is available (arrival if available,
+            first otherwise).
             Default: "arrival".
 
         """
@@ -63,6 +135,63 @@ class PeriodCondition (DBCondition):
         self.start = start
         self.end = end
         self.date = date
+
+
+class OrgsCondition (DBCondition):
+    """Organization Condition for qualifying an entity.
+
+    Specifies the organizations of interest: only their activity will
+    be considered.
+    """
+
+    def __init__ (self, orgs, actors = "senders", date = "arrival"):
+        """Instatiation of the object.
+
+        Parameters
+        ----------
+
+        orgs: list of str
+           List of organziations of interest 
+        actors: {"senders"}
+            Kind of actors to consider
+        date: { "first" | "arrival" | "check" }
+            Select "first_date" or "arrival_date" from messages,
+            ir check which one is available (arrival if available,
+            first otherwise).
+            Default: "arrival".
+
+        """
+
+        self.org_names = orgs
+        self.actors = actors
+        self.date = date
+
+    def filter (self, query):
+        """Filter to apply for this condition
+
+        Parameters
+        ----------
+
+        query: Query
+           Query to which the filter will be applied
+
+        """
+
+        if self.date == "check":
+            # Check if arrival_date is available
+            if query.null_arrival().count() == 0:
+                self.date = "arrival"
+            else:
+                self.date = "first"
+        # Get the session for this query, use it for getting org ids,
+        # and build the filter
+        session = inspect(query).session
+        query_orgs = session.query().select_orgs() \
+            .filter_orgs (self.org_names)
+        self.org_ids = [org.org_id for org in query_orgs.all()]
+        return query.filter_org_ids(list = self.org_ids,
+                                    kind = self.actors,
+                                    date = self.date)
 
 
 if __name__ == "__main__":

--- a/grimoirelib_alch/family/scm.py
+++ b/grimoirelib_alch/family/scm.py
@@ -23,85 +23,10 @@
 ##   Jesus M. Gonzalez-Barahona <jgb@bitergia.com>
 ##
 
-from common import DBFamily, DBCondition
+from common import DBFamily, DBCondition, Entities, Entity
 from grimoirelib_alch.query.scm import DB, Query
 from sqlalchemy import inspect
 
-class Entities(type):
-    """Watcher for a metaclass, maintaining a dictionary with its subclasses
-
-    This watcher class maintains a dictionary with all the subclasses of
-    the metaclass that uses it.
-
-    Attributes
-    ----------
-
-    subclasses : dictionary
-        Subclasses of metaclass, keyed by name attribute of each subclass
-        (values are the subclasses themselves)
-
-    """
-
-    subclasses = {}
-
-    def __init__(cls, name, bases, clsdict):
-        """Add subclass cls to subclasses, keyed by its name attribute.
-
-        """
-
-        if clsdict['name'] is not None:
-            Entities.subclasses[clsdict['name']] = cls
-    
-class Entity ():
-    """Metaclass, root of all entities.
-
-    This is the root of the hierarchy of entities.
-    It uses a watcher for keeping a dictionary with all its subclasses.
-    Defines attributes and methods to be used in all the hierarchy.
-
-    Attributes
-    ----------
-
-    name: str
-        Entity name used for the entity represented by the class
-    desc: str
-        Description of the entity (one line)
-    longdesc: str
-        Description of the entity (long)
-
-    Methods
-    -------
-
-    query (q)
-        Returns the query to produce the entity
-
-    """
-
-    __metaclass__ = Entities
-
-    name = None
-    desc = None
-    longdesc = None
-
-    @staticmethod
-    def query (q):
-        """Return the query to produce this entity.
-
-        Parameters
-        ----------
-
-        q: query.scm.Query
-            Base query
-
-        Returns
-        -------
-
-        query.scm.Query
-            Query with the needed filters to produce the entity.
-
-        """
-
-        raise Exception ("query(): real entities should provide real code")
 
 class NCommits (Entity):
     """Number of commits

--- a/grimoirelib_alch/query/its.py
+++ b/grimoirelib_alch/query/its.py
@@ -50,7 +50,7 @@ class DB (GrimoireDatabase):
 
         return Query
 
-    def _create_tables(self):
+    def _create_tables(self, tables = None, tables_id = None):
         """Create all SQLAlchemy tables.
 
         Builds a SQLAlchemy class per SQL table, by using _table().
@@ -97,6 +97,19 @@ class DB (GrimoireDatabase):
             bases = (self.Base,), name = 'UPeople',
             tablename = 'upeople',
             schemaname = self.schema_id)
+        DB.Companies = GrimoireDatabase._table (
+            bases = (self.Base,), name = 'Companies',
+            tablename = 'companies',
+            schemaname = self.schema_id,
+            columns = dict (
+                id = Column(Integer, primary_key = True)
+                )
+            )
+        DB.UPeopleCompanies = GrimoireDatabase._table (
+            bases = (self.Base,), name = 'UPeopleCompanies',
+            tablename = 'upeople_companies',
+            schemaname = self.schema_id,
+            )
 
 
 class Query (GrimoireQuery):
@@ -243,6 +256,25 @@ class Query (GrimoireQuery):
         return query
 
 
+    def select_orgs (self):
+        """Select organizations data.
+
+        Include id and name, as they appear in the companies table.
+        Warning: doesn't join other tables. For now, only works alone.
+
+        Returns
+        -------
+
+        Query
+            Including new columns in SELECT
+        
+        """
+
+        query = self.add_columns (label("org_id", DB.Companies.id),
+                                  label("org_name", DB.Companies.name))
+        return query
+
+
     def filter_period(self, start = None, end = None, date = "change"):
         """Filter variable for a period
 
@@ -267,6 +299,63 @@ class Query (GrimoireQuery):
         if end is not None:
             self.end = end
             query = query.filter(date_field < end.isoformat())
+        return query
+
+
+    def filter_orgs (self, orgs):
+        """Filter organizations matching a list of names
+
+        Fiters query by a list of organization names, checking for
+        them in the companies table.
+
+        Parameters
+        ----------
+        
+        orgs: list of str
+            List of organizations
+
+        """
+
+        query = self
+        query = query.filter(DB.Companies.name.in_(orgs))
+        return query
+
+
+    def filter_org_ids (self, list, kind):
+        """Filter organizations matching a list of organization ids
+
+        Fiters query by a list of organization ids.
+
+        Parameters
+        ----------
+        
+        list: list of int
+            List of organization ids
+        kind: {"openers", "closers", "changers"}
+           Kind of person to select
+
+        """
+
+        query = self
+        if kind == "changers":
+            person_id = DB.Changes.changed_by
+            date_id = DB.Changes.changed_on
+        elif kind in ("closers", "openers"):
+            raise Exception ("filter_org_ids: " \
+                                 "Kind not yet implemented %s." \
+                                 % kind)
+        else:
+            raise Exception ("filter_org_ids: Unknown kind %s." \
+                                 % kind)
+        query = query \
+            .join (DB.UPeopleCompanies,
+                   DB.PeopleUPeople.upeople_id == \
+                       DB.UPeopleCompanies.upeople_id) \
+            .filter (date_id.between (
+                           DB.UPeopleCompanies.init,
+                           DB.UPeopleCompanies.end
+                           )) \
+            .filter (DB.UPeopleCompanies.company_id.in_(list))
         return query
 
 

--- a/grimoirelib_alch/query/its.py
+++ b/grimoirelib_alch/query/its.py
@@ -67,6 +67,7 @@ class DB (GrimoireDatabase):
                 issue_id = Column(Integer,
                                   ForeignKey(self.schema + '.' + 'issues.id'))
                 ))
+
         DB.Issues = GrimoireDatabase._table (
             bases = (self.Base,), name = 'Issues',
             tablename = 'issues',
@@ -76,10 +77,12 @@ class DB (GrimoireDatabase):
                     Integer,
                     ForeignKey(self.schema + '.' + 'people.id'))     
                 ))
+
         DB.People = GrimoireDatabase._table (
             bases = (self.Base,), name = 'People',
             tablename = 'people',
             schemaname = self.schema)
+
         DB.PeopleUPeople = GrimoireDatabase._table (
             bases = (self.Base,), name = 'PeopleUPeople',
             tablename = 'people_upeople',
@@ -89,27 +92,33 @@ class DB (GrimoireDatabase):
                     Integer,
                     ForeignKey(self.schema_id + '.' + 'upeople.id'))
                 ))
+
         DB.Trackers = GrimoireDatabase._table (
             bases = (self.Base,), name = 'Trackers',
             tablename = 'trackers',
             schemaname = self.schema)
+
         DB.UPeople = GrimoireDatabase._table (
             bases = (self.Base,), name = 'UPeople',
             tablename = 'upeople',
             schemaname = self.schema_id)
-        DB.Companies = GrimoireDatabase._table (
-            bases = (self.Base,), name = 'Companies',
-            tablename = 'companies',
-            schemaname = self.schema_id,
-            columns = dict (
-                id = Column(Integer, primary_key = True)
+
+        if "companies" in tables_id:
+            DB.Companies = GrimoireDatabase._table (
+                bases = (self.Base,), name = 'Companies',
+                tablename = 'companies',
+                schemaname = self.schema_id,
+                columns = dict (
+                    id = Column(Integer, primary_key = True)
+                    )
                 )
-            )
-        DB.UPeopleCompanies = GrimoireDatabase._table (
-            bases = (self.Base,), name = 'UPeopleCompanies',
-            tablename = 'upeople_companies',
-            schemaname = self.schema_id,
-            )
+
+        if "upeople_companies" in tables_id:
+            DB.UPeopleCompanies = GrimoireDatabase._table (
+                bases = (self.Base,), name = 'UPeopleCompanies',
+                tablename = 'upeople_companies',
+                schemaname = self.schema_id,
+                )
 
 
 class Query (GrimoireQuery):

--- a/grimoirelib_alch/query/mls.py
+++ b/grimoirelib_alch/query/mls.py
@@ -266,6 +266,26 @@ class Query (GrimoireQuery):
             DB.Messages.message_ID == DB.MessagesPeople.message_id)
         return query
 
+
+    def select_orgs (self):
+        """Select organizations data.
+
+        Include id and name, as they appear in the companies table.
+        Warning: doesn't join other tables. For now, only works alone.
+
+        Returns
+        -------
+
+        Query
+            Including new columns in SELECT
+        
+        """
+
+        query = self.add_columns (label("org_id", DB.Companies.id),
+                                  label("org_name", DB.Companies.name))
+        return query
+
+
     def filter_period(self, start = None, end = None, date = "arrival"):
         """Filter for a period, according to message dates
 

--- a/grimoirelib_alch/query/mls.py
+++ b/grimoirelib_alch/query/mls.py
@@ -69,6 +69,7 @@ class DB (GrimoireDatabase):
                     ForeignKey(self.schema + '.' + \
                                    'mailing_lists.mailing_list_url'))
                 ))
+
         DB.MessagesPeople = GrimoireDatabase._table (
             bases = (self.Base,), name = 'MessagesPeople',
             tablename = 'messages_people',
@@ -87,10 +88,12 @@ class DB (GrimoireDatabase):
                     ForeignKey(self.schema + '.' + \
                                    'people.email_address'))     
                 ))
+
         DB.People = GrimoireDatabase._table (
             bases = (self.Base,), name = 'People',
             tablename = 'people',
             schemaname = self.schema)
+
         DB.PeopleUPeople = GrimoireDatabase._table (
             bases = (self.Base,), name = 'PeopleUPeople',
             tablename = 'people_upeople',
@@ -108,14 +111,34 @@ class DB (GrimoireDatabase):
                     ),
                 )
             )
+
         DB.MailingLists = GrimoireDatabase._table (
             bases = (self.Base,), name = 'MailingLists',
             tablename = 'mailing_lists',
             schemaname = self.schema)
+
         DB.UPeople = GrimoireDatabase._table (
             bases = (self.Base,), name = 'UPeople',
             tablename = 'upeople',
             schemaname = self.schema_id)
+
+        if "companies" in tables_id:
+            DB.Companies = GrimoireDatabase._table (
+                bases = (self.Base,), name = 'Companies',
+                tablename = 'companies',
+                schemaname = self.schema_id,
+                columns = dict (
+                    id = Column(Integer, primary_key = True)
+                    )
+                )
+
+        if "upeople_companies" in tables_id:
+            DB.UPeopleCompanies = GrimoireDatabase._table (
+                bases = (self.Base,), name = 'UPeopleCompanies',
+                tablename = 'upeople_companies',
+                schemaname = self.schema_id,
+                )
+
 
 class Query (GrimoireQuery):
     """Class for dealing with MLS queries"""
@@ -287,6 +310,74 @@ class Query (GrimoireQuery):
         if end is not None:
             self.end = end
             query = query.filter(date_field < end.isoformat())
+        return query
+
+
+    def filter_orgs (self, orgs):
+        """Filter organizations matching a list of names
+
+        Fiters query by a list of organization names, checking for
+        them in the companies table.
+
+        Parameters
+        ----------
+        
+        orgs: list of str
+            List of organizations
+
+        """
+
+        query = self
+        query = query.filter(DB.Companies.name.in_(orgs))
+        return query
+
+
+    def filter_org_ids (self, list, kind = "senders", date = "arrival"):
+        """Filter organizations matching a list of organization ids
+
+        Fiters query by a list of organization ids.
+
+        Parameters
+        ----------
+        
+        list: list of int
+            List of organization ids
+        kind: {"senders", "starters", "followers"}
+           Kind of person to select
+        date: {"arrival"|"first"}
+           consider either arrival date or first date (default: arrival)
+
+        """
+
+        query = self
+        if date == "arrival":
+            date_field = DB.Messages.arrival_date
+        elif date == "first":
+            date_field = DB.Messages.first_date
+        else:
+            raise Exception ("select_activeperiod: Unknown kind of date: %s." \
+                                 % date)
+        if kind == "senders":
+            query = query.filter (DB.MessagesPeople.type_of_recipient == \
+                                      "From")
+        elif kind in ("starters", "followers"):
+            raise Exception ("filter_org_ids: " \
+                                 "Kind not yet implemented %s." \
+                                 % kind)
+        else:
+            raise Exception ("filter_org_ids: Unknown kind %s." \
+                                 % kind)
+        query = query \
+            .filter (DB.MessagesPeople.email_address == \
+                        DB.PeopleUPeople.people_id) \
+            .join (DB.UPeopleCompanies,
+                   DB.PeopleUPeople.upeople_id == \
+                       DB.UPeopleCompanies.upeople_id) \
+            .filter (date_field.between (
+                           DB.UPeopleCompanies.init,
+                           DB.UPeopleCompanies.end
+                           )) \
+            .filter (DB.UPeopleCompanies.company_id.in_(list))
         return query
 
 

--- a/grimoirelib_alch/query/mls.py
+++ b/grimoirelib_alch/query/mls.py
@@ -50,7 +50,7 @@ class DB (GrimoireDatabase):
 
         return Query
 
-    def _create_tables(self):
+    def _create_tables(self, tables = None, tables_id = None):
         """Create all SQLAlchemy tables.
 
         Builds a SQLAlchemy class per SQL table, by using _table().

--- a/grimoirelib_alch/query/scm.py
+++ b/grimoirelib_alch/query/scm.py
@@ -50,7 +50,7 @@ class DB (GrimoireDatabase):
 
         return Query
 
-    def _create_tables(self):
+    def _create_tables(self, tables = None, tables_id = None):
         """Create all SQLAlchemy tables.
 
         Builds a SQLAlchemy class per SQL table, by using _table().
@@ -152,20 +152,22 @@ class DB (GrimoireDatabase):
             tablename = 'upeople',
             schemaname = self.schema_id)
 
-        DB.Companies = GrimoireDatabase._table (
-            bases = (self.Base,), name = 'Companies',
-            tablename = 'companies',
-            schemaname = self.schema_id,
-            columns = dict (
-                id = Column(Integer, primary_key = True)
+        if "companies" in tables_id:
+            DB.Companies = GrimoireDatabase._table (
+                bases = (self.Base,), name = 'Companies',
+                tablename = 'companies',
+                schemaname = self.schema_id,
+                columns = dict (
+                    id = Column(Integer, primary_key = True)
+                    )
                 )
-            )
 
-        DB.UPeopleCompanies = GrimoireDatabase._table (
-            bases = (self.Base,), name = 'UPeopleCompanies',
-            tablename = 'upeople_companies',
-            schemaname = self.schema_id,
-            )
+        if "upeople_companies" in tables_id:
+            DB.UPeopleCompanies = GrimoireDatabase._table (
+                bases = (self.Base,), name = 'UPeopleCompanies',
+                tablename = 'upeople_companies',
+                schemaname = self.schema_id,
+                )
 
 class Query (GrimoireQuery):
     """Class for dealing with SCM queries"""

--- a/grimoirelib_alch/query/scr.py
+++ b/grimoirelib_alch/query/scr.py
@@ -55,7 +55,7 @@ class DB (ITSDB):
 
         return Query
 
-    def _create_tables(self):
+    def _create_tables(self, tables = None, tables_id = None):
         """Create all SQLAlchemy tables.
 
         Builds a SQLAlchemy class per SQL table, by using _table().
@@ -67,7 +67,7 @@ class DB (ITSDB):
 
         """
 
-        ITSDB._create_tables(self)
+        ITSDB._create_tables(self, tables, tables_id)
         DB.IssuesExtGerrit = GrimoireDatabase._table (
             bases = (self.Base,), name = 'IssuesExtGerrit',
             tablename = 'issues_ext_gerrit',

--- a/grimoirelib_alch/tests/test_family_its.py
+++ b/grimoirelib_alch/tests/test_family_its.py
@@ -1,0 +1,59 @@
+# -*- coding: utf-8 -*-
+
+## Copyright (C) 2014 Bitergia
+##
+## This program is free software; you can redistribute it and/or modify
+## it under the terms of the GNU General Public License as published by
+## the Free Software Foundation; either version 3 of the License, or
+## (at your option) any later version.
+##
+## This program is distributed in the hope that it will be useful,
+## but WITHOUT ANY WARRANTY; without even the implied warranty of
+## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+## GNU General Public License for more details.
+##
+## You should have received a copy of the GNU General Public License
+## along with this program; if not, write to the Free Software
+## Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+##
+## Unit tests for family.its
+## 
+## Authors:
+##   Jesus M. Gonzalez-Barahona <jgb@bitergia.com>
+##
+
+from grimoirelib_alch.query.its import DB
+from grimoirelib_alch.family.its import (
+    ITS,
+    PeriodCondition
+    )
+from datetime import datetime
+import unittest
+
+url = 'mysql://jgb:XXX@localhost/'
+schema = 'cp_bicho_GrimoireLibTests'
+schema_id = 'cp_cvsanaly_GrimoireLibTests'
+start = datetime(2013,11,13)
+end = datetime(2014,2,1)
+
+class TestITS (unittest.TestCase):
+
+    def setUp (self):
+
+        self.database = DB (url = url,
+                            schema = schema,
+                            schema_id = schema_id)
+        self.session = self.database.build_session()
+        self.start = start
+        self.end = end
+
+
+    def test_no_condition (self):
+        """Test ITS object with no conditions"""
+
+        data = ITS (datasource = self.database, name = "npersons")
+        self.assertEqual (data.total(), 27)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/grimoirelib_alch/tests/test_family_its_orgs.py
+++ b/grimoirelib_alch/tests/test_family_its_orgs.py
@@ -51,9 +51,9 @@ class TestITSOrgs (unittest.TestCase):
 
         orgs = OrgsCondition (orgs = ("company2", "company3", "company1"),
                               actors = "changers")
-        data = ITS (datasource = self.database, name = "ncommits",
+        data = ITS (datasource = self.database, name = "npersons",
                     conditions = (orgs,))
-        self.assertEqual (data.total(), 20115)
+        self.assertEqual (data.total(), 15)
 
 if __name__ == "__main__":
     unittest.main()

--- a/grimoirelib_alch/tests/test_family_its_orgs.py
+++ b/grimoirelib_alch/tests/test_family_its_orgs.py
@@ -1,0 +1,59 @@
+# -*- coding: utf-8 -*-
+
+## Copyright (C) 2015 Bitergia
+##
+## This program is free software; you can redistribute it and/or modify
+## it under the terms of the GNU General Public License as published by
+## the Free Software Foundation; either version 3 of the License, or
+## (at your option) any later version.
+##
+## This program is distributed in the hope that it will be useful,
+## but WITHOUT ANY WARRANTY; without even the implied warranty of
+## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+## GNU General Public License for more details.
+##
+## You should have received a copy of the GNU General Public License
+## along with this program; if not, write to the Free Software
+## Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+##
+## Unit tests for family.its related to organizations
+## 
+## Authors:
+##   Jesus M. Gonzalez-Barahona <jgb@bitergia.com>
+##
+
+from grimoirelib_alch.query.its import DB
+from grimoirelib_alch.family.its import (
+    ITS, OrgsCondition
+    )
+from datetime import datetime
+import unittest
+
+url = 'mysql://jgb:XXX@localhost/'
+schema = 'cp_bicho_GrimoireLibTests'
+schema_id = 'cp_cvsanaly_GrimoireLibTests'
+start = datetime(2013,11,13)
+end = datetime(2014,2,1)
+
+class TestITSOrgs (unittest.TestCase):
+
+    def setUp (self):
+
+        self.database = DB (url = url,
+                            schema = schema,
+                            schema_id = schema_id)
+        self.session = self.database.build_session()
+        self.start = start
+        self.end = end
+
+    def test_orgs_condition (self):
+        """Test ITS object with an organizations condition"""
+
+        orgs = OrgsCondition (orgs = ("company2", "company3", "company1"),
+                              actors = "changers")
+        data = ITS (datasource = self.database, name = "ncommits",
+                    conditions = (orgs,))
+        self.assertEqual (data.total(), 20115)
+
+if __name__ == "__main__":
+    unittest.main()

--- a/grimoirelib_alch/tests/test_family_mls.py
+++ b/grimoirelib_alch/tests/test_family_mls.py
@@ -1,0 +1,59 @@
+# -*- coding: utf-8 -*-
+
+## Copyright (C) 2014 Bitergia
+##
+## This program is free software; you can redistribute it and/or modify
+## it under the terms of the GNU General Public License as published by
+## the Free Software Foundation; either version 3 of the License, or
+## (at your option) any later version.
+##
+## This program is distributed in the hope that it will be useful,
+## but WITHOUT ANY WARRANTY; without even the implied warranty of
+## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+## GNU General Public License for more details.
+##
+## You should have received a copy of the GNU General Public License
+## along with this program; if not, write to the Free Software
+## Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+##
+## Unit tests for family.its
+## 
+## Authors:
+##   Jesus M. Gonzalez-Barahona <jgb@bitergia.com>
+##
+
+from grimoirelib_alch.query.mls import DB
+from grimoirelib_alch.family.mls import (
+    MLS,
+    PeriodCondition
+    )
+from datetime import datetime
+import unittest
+
+url = 'mysql://jgb:XXX@localhost/'
+schema = 'cp_mlstats_GrimoireLibTests'
+schema_id = 'cp_cvsanaly_GrimoireLibTests'
+start = datetime(2013,11,13)
+end = datetime(2014,2,1)
+
+class TestMLS (unittest.TestCase):
+
+    def setUp (self):
+
+        self.database = DB (url = url,
+                            schema = schema,
+                            schema_id = schema_id)
+        self.session = self.database.build_session()
+        self.start = start
+        self.end = end
+
+
+    def test_no_condition (self):
+        """Test ITS object with no conditions"""
+
+        data = MLS (datasource = self.database, name = "npersons")
+        self.assertEqual (data.total(), 10)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/grimoirelib_alch/tests/test_family_mls_orgs.py
+++ b/grimoirelib_alch/tests/test_family_mls_orgs.py
@@ -24,7 +24,7 @@
 
 from grimoirelib_alch.query.mls import DB
 from grimoirelib_alch.family.mls import (
-    MLS, OrgsCondition
+    MLS, OrgsCondition, PeriodCondition
     )
 from datetime import datetime
 import unittest
@@ -54,6 +54,20 @@ class TestMLSOrgs (unittest.TestCase):
         data = MLS (datasource = self.database, name = "npersons",
                     conditions = (orgs,))
         self.assertEqual (data.total(), 6)
+
+    def test_orgs_period_condition (self):
+        """Test MLS object with organizations and period conditions"""
+
+        orgs = OrgsCondition (orgs = ("company2", "company3", "company1"),
+                              actors = "senders", date = "check")
+        period = PeriodCondition (start = self.start, end = self.end,
+                                  date = "check")
+        data = MLS (datasource = self.database, name = "npersons",
+                    conditions = (orgs, period))
+        self.assertEqual (data.total(), 2)
+        data = MLS (datasource = self.database, name = "npersons",
+                    conditions = (period, orgs))
+        self.assertEqual (data.total(), 2)
 
 if __name__ == "__main__":
     unittest.main()

--- a/grimoirelib_alch/tests/test_family_mls_orgs.py
+++ b/grimoirelib_alch/tests/test_family_mls_orgs.py
@@ -1,0 +1,59 @@
+# -*- coding: utf-8 -*-
+
+## Copyright (C) 2015 Bitergia
+##
+## This program is free software; you can redistribute it and/or modify
+## it under the terms of the GNU General Public License as published by
+## the Free Software Foundation; either version 3 of the License, or
+## (at your option) any later version.
+##
+## This program is distributed in the hope that it will be useful,
+## but WITHOUT ANY WARRANTY; without even the implied warranty of
+## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+## GNU General Public License for more details.
+##
+## You should have received a copy of the GNU General Public License
+## along with this program; if not, write to the Free Software
+## Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+##
+## Unit tests for family.mls related to organizations
+## 
+## Authors:
+##   Jesus M. Gonzalez-Barahona <jgb@bitergia.com>
+##
+
+from grimoirelib_alch.query.mls import DB
+from grimoirelib_alch.family.mls import (
+    MLS, OrgsCondition
+    )
+from datetime import datetime
+import unittest
+
+url = 'mysql://jgb:XXX@localhost/'
+schema = 'cp_mlstats_GrimoireLibTests'
+schema_id = 'cp_cvsanaly_GrimoireLibTests'
+start = datetime(2013,11,13)
+end = datetime(2014,2,1)
+
+class TestMLSOrgs (unittest.TestCase):
+
+    def setUp (self):
+
+        self.database = DB (url = url,
+                            schema = schema,
+                            schema_id = schema_id)
+        self.session = self.database.build_session()
+        self.start = start
+        self.end = end
+
+    def test_orgs_condition (self):
+        """Test MLS object with an organizations condition"""
+
+        orgs = OrgsCondition (orgs = ("company2", "company3", "company1"),
+                              actors = "senders", date = "check")
+        data = MLS (datasource = self.database, name = "npersons",
+                    conditions = (orgs,))
+        self.assertEqual (data.total(), 6)
+
+if __name__ == "__main__":
+    unittest.main()

--- a/grimoirelib_alch/tests/test_query_its.py
+++ b/grimoirelib_alch/tests/test_query_its.py
@@ -32,7 +32,7 @@ schema_id = 'cp_cvsanaly_GrimoireLibTests'
 start = datetime(2013,11,13)
 end = datetime(2014,2,1)
 
-class TestSCMQuery (unittest.TestCase):
+class TestITSQuery (unittest.TestCase):
 
     def setUp (self):
         database = DB (url = url,

--- a/grimoirelib_alch/tests/test_query_its.py
+++ b/grimoirelib_alch/tests/test_query_its.py
@@ -1,0 +1,62 @@
+# -*- coding: utf-8 -*-
+
+## Copyright (C) 2015 Bitergia
+##
+## This program is free software; you can redistribute it and/or modify
+## it under the terms of the GNU General Public License as published by
+## the Free Software Foundation; either version 3 of the License, or
+## (at your option) any later version.
+##
+## This program is distributed in the hope that it will be useful,
+## but WITHOUT ANY WARRANTY; without even the implied warranty of
+## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+## GNU General Public License for more details.
+##
+## You should have received a copy of the GNU General Public License
+## along with this program; if not, write to the Free Software
+## Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+##
+## Unit tests for query/its.py
+## 
+## Authors:
+##   Jesus M. Gonzalez-Barahona <jgb@bitergia.com>
+##
+
+from grimoirelib_alch.query.its import DB, Query
+from datetime import datetime
+import unittest
+
+url = 'mysql://jgb:XXX@localhost/'
+schema = 'cp_bicho_GrimoireLibTests'
+schema_id = 'cp_cvsanaly_GrimoireLibTests'
+start = datetime(2013,11,13)
+end = datetime(2014,2,1)
+
+class TestSCMQuery (unittest.TestCase):
+
+    def setUp (self):
+        database = DB (url = url,
+                       schema = schema,
+                       schema_id = schema_id)
+        self.session = database.build_session(Query, echo = False)
+
+
+    def test_select_personsdata_uid (self):
+        """Test select_personsdata_uid"""
+
+        correct = [
+            [(50L, u'Michael Movchin'), (51L, u'Peter Bena')],
+            132,
+            16500]
+
+        res = self.session.query().select_personsdata_uid("openers")
+        self.assertEqual (res.distinct().limit(2).all(),
+                          correct[0])
+        self.assertEqual (res.count(),
+                          correct[1])
+        self.assertEqual (res.filter_period(start=start, end=end).count(),
+                          correct[2])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/grimoirelib_alch/tests/test_query_its_orgs.py
+++ b/grimoirelib_alch/tests/test_query_its_orgs.py
@@ -1,0 +1,81 @@
+# -*- coding: utf-8 -*-
+
+## Copyright (C) 2015 Bitergia
+##
+## This program is free software; you can redistribute it and/or modify
+## it under the terms of the GNU General Public License as published by
+## the Free Software Foundation; either version 3 of the License, or
+## (at your option) any later version.
+##
+## This program is distributed in the hope that it will be useful,
+## but WITHOUT ANY WARRANTY; without even the implied warranty of
+## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+## GNU General Public License for more details.
+##
+## You should have received a copy of the GNU General Public License
+## along with this program; if not, write to the Free Software
+## Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+##
+## Unit tests for scm_its.py related to organizations
+## 
+## Authors:
+##   Jesus M. Gonzalez-Barahona <jgb@bitergia.com>
+##
+
+from grimoirelib_alch.query.its import DB, Query
+import unittest
+
+url = 'mysql://jgb:XXX@localhost/'
+schema = 'cp_bicho_GrimoireLibTests'
+schema_id = 'cp_cvsanaly_GrimoireLibTests'
+
+class TestSCMQueryOrgs (unittest.TestCase):
+
+    def setUp (self):
+        database = DB (url = url,
+                       schema = schema,
+                       schema_id = schema_id)
+        self.session = database.build_session(Query, echo = False)
+
+    def test_select_orgs (self):
+        """Test select_orgs
+
+        """
+
+        correct = [(11, "company4"),
+                   (12, "company1"),
+                   (13, "company2"),
+                   (14, "company5"),
+                   (15, "company3")]
+
+        res = self.session.query().select_orgs()
+        self.assertEqual (res.limit(5).all(), correct)
+
+    def test_filter_orgs (self):
+        """Test select_orgs
+
+        """
+
+        correct = [(11, "company4"),
+                   (12, "company1"),
+                   (14, "company5"),
+                   (15, "company3")]
+
+        res = self.session.query().select_orgs() \
+            .filter_orgs(org[1] for org in correct)
+        self.assertEqual (res.all(), correct)
+
+    def test_filter_org_ids (self):
+        """Test filter_org_ids
+
+        """
+
+        correct = (25,)
+
+        res = self.session.query().select_personsdata_uid("changers") \
+            .filter_org_ids(list = (11,12,), kind = "changers")
+        self.assertEqual (res.distinct().count(), correct[0])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/grimoirelib_alch/tests/test_query_mls.py
+++ b/grimoirelib_alch/tests/test_query_mls.py
@@ -1,0 +1,63 @@
+# -*- coding: utf-8 -*-
+
+## Copyright (C) 2015 Bitergia
+##
+## This program is free software; you can redistribute it and/or modify
+## it under the terms of the GNU General Public License as published by
+## the Free Software Foundation; either version 3 of the License, or
+## (at your option) any later version.
+##
+## This program is distributed in the hope that it will be useful,
+## but WITHOUT ANY WARRANTY; without even the implied warranty of
+## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+## GNU General Public License for more details.
+##
+## You should have received a copy of the GNU General Public License
+## along with this program; if not, write to the Free Software
+## Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+##
+## Unit tests for query.mls
+## 
+## Authors:
+##   Jesus M. Gonzalez-Barahona <jgb@bitergia.com>
+##
+
+from grimoirelib_alch.query.mls import DB, Query
+from datetime import datetime
+import unittest
+
+url = 'mysql://jgb:XXX@localhost/'
+schema = 'cp_mlstats_GrimoireLibTests'
+schema_id = 'cp_cvsanaly_GrimoireLibTests'
+start = datetime(2013,01,13)
+end = datetime(2014,2,1)
+
+class TestMLSQuery (unittest.TestCase):
+
+    def setUp (self):
+        database = DB (url = url,
+                       schema = schema,
+                       schema_id = schema_id)
+        self.session = database.build_session(Query, echo = False)
+
+
+    def test_select_personsdata_uid (self):
+        """Test select_personsdata_uid"""
+
+        correct = [
+            [(186L, u'Brad Jorsch'), (15L, u'Brion Vibber')],
+            198,
+            35]
+
+        res = self.session.query().select_personsdata_uid("senders")
+        self.assertEqual (res.distinct().limit(2).all(),
+                          correct[0])
+        self.assertEqual (res.count(),
+                          correct[1])
+        res = res.filter_period(start=start, end=end, date ="first")
+        self.assertEqual (res.count(),
+                          correct[2])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/grimoirelib_alch/tests/test_query_mls_orgs.py
+++ b/grimoirelib_alch/tests/test_query_mls_orgs.py
@@ -1,0 +1,82 @@
+# -*- coding: utf-8 -*-
+
+## Copyright (C) 2015 Bitergia
+##
+## This program is free software; you can redistribute it and/or modify
+## it under the terms of the GNU General Public License as published by
+## the Free Software Foundation; either version 3 of the License, or
+## (at your option) any later version.
+##
+## This program is distributed in the hope that it will be useful,
+## but WITHOUT ANY WARRANTY; without even the implied warranty of
+## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+## GNU General Public License for more details.
+##
+## You should have received a copy of the GNU General Public License
+## along with this program; if not, write to the Free Software
+## Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+##
+## Unit tests for query.mls related to organizations
+## 
+## Authors:
+##   Jesus M. Gonzalez-Barahona <jgb@bitergia.com>
+##
+
+from grimoirelib_alch.query.mls import DB, Query
+import unittest
+
+url = 'mysql://jgb:XXX@localhost/'
+schema = 'cp_mlstats_GrimoireLibTests'
+schema_id = 'cp_cvsanaly_GrimoireLibTests'
+
+class TestSCMQueryOrgs (unittest.TestCase):
+
+    def setUp (self):
+        database = DB (url = url,
+                       schema = schema,
+                       schema_id = schema_id)
+        self.session = database.build_session(Query, echo = False)
+
+    def test_select_orgs (self):
+        """Test select_orgs
+
+        """
+
+        correct = [(11, "company4"),
+                   (12, "company1"),
+                   (13, "company2"),
+                   (14, "company5"),
+                   (15, "company3")]
+
+        res = self.session.query().select_orgs()
+        self.assertEqual (res.limit(5).all(), correct)
+
+    def test_filter_orgs (self):
+        """Test select_orgs
+
+        """
+
+        correct = [(11, "company4"),
+                   (12, "company1"),
+                   (14, "company5"),
+                   (15, "company3")]
+
+        res = self.session.query().select_orgs() \
+            .filter_orgs(org[1] for org in correct)
+        self.assertEqual (res.all(), correct)
+
+    def test_filter_org_ids (self):
+        """Test filter_org_ids
+
+        """
+
+        correct = (4,)
+
+        res = self.session.query().select_personsdata_uid("senders") \
+            .filter_org_ids(list = (11,12,), kind = "senders",
+                            date = "first")
+        self.assertEqual (res.distinct().count(), correct[0])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/vizgrimoire/analysis/ages.py
+++ b/vizgrimoire/analysis/ages.py
@@ -257,7 +257,7 @@ class Ages(Analyses):
         Creates JSON files with the results of the report for birth and aging:
          ds-demographics-birth.json, ds-demographics-aging.json,
          with ds being "scm" or "its".
-        Only works for SCM or ITS data sources.
+        Only works for SCM, ITS, MLS data sources.
         
         Parameters
         ----------
@@ -278,7 +278,8 @@ class Ages(Analyses):
             logging.info("Error: data_source not supported for Aging")
             return
         demos = self.result(data_source)
-        log_message = "Producing report for study: Aging (done!)"
+        log_message = "Producing report for study: Aging " + prefix + \
+            " (done!)"
         if self.filters.COMPANY in self.analysis_dict:
             org = self.analysis_dict[self.filters.COMPANY]
             file_birth = destdir + "/" + org + "-" + prefix + "-com-demographics-birth.json"


### PR DESCRIPTION
This set of patches adds support for ITS and MLS in vizgrimoire/analysis/ages.py.

For doing that, it implements metrics and queries in grimoirelib_alch both for ITS and MLS. In the process, new tests were included, and some minor issues were fixed.

In addition, support for checking if a database has companies tables is included before trying to use it.

Important note: support in vizgrimoire/ITS.py and vizgrimoire/MLS.py is still missing. It has to be implemented for the new demographics metrics to be produced by report_tool.py.