### PR TITLE
Changing "name" for unique identifiers from uuid identifier.

### DIFF
--- a/grimoirelib_alch/query/its.py
+++ b/grimoirelib_alch/query/its.py
@@ -198,7 +198,7 @@ class Query (GrimoireQuery):
         """
 
         query = self.add_columns (label("person_id", DB.UIdentities.uuid),
-                                  label("name", DB.UIdentities.uuid))
+                                  label("name", DB.UIdentities.identifier))
         if kind == "openers":
             person = DB.Issues.submitted_by
             table = DB.Issues

--- a/grimoirelib_alch/query/mls.py
+++ b/grimoirelib_alch/query/mls.py
@@ -207,7 +207,7 @@ class Query (GrimoireQuery):
         """
 
         query = self.add_columns (label("person_id", DB.UIdentities.uuid),
-                                  label("name", DB.UIdentities.uuid))
+                                  label("name", DB.UIdentities.identifier))
         self.joined.append (DB.UIdentities)
         if kind == "senders":
             if DB.PeopleUIdentities not in self.joined:

--- a/grimoirelib_alch/query/scm.py
+++ b/grimoirelib_alch/query/scm.py
@@ -241,7 +241,7 @@ class Query (GrimoireQuery):
         """
         
         query = self.add_columns (label("id", func.distinct(DB.UIdentities.uuid)),
-                                  label("name", DB.UIdentities.uuid)) \
+                                  label("name", DB.UIdentities.identifier)) \
                 .join (DB.PeopleUIdentities,
                        DB.UIdentities.uuid == DB.PeopleUIdentities.uuid)
         if kind == "authors":
@@ -357,7 +357,7 @@ class Query (GrimoireQuery):
             raise Exception ("select_personsdata_uid: Unknown kind %s." \
                              % kind)
         query = self.add_columns (label("person_id", DB.UIdentities.uuid),
-                                  label("name", DB.UIdentities.uuid))
+                                  label("name", DB.UIdentities.identifier))
         if not self.joined:
             # First table, UIdentities is in FROM
             self.joined.append (DB.UIdentities)


### PR DESCRIPTION
Changing "name" for unique identifiers from uidentities.uuid to uidentities.identifier, which is the field with the name. This was causing that uuids were appearing in results for queries instead of names.